### PR TITLE
assume (:pointer foo) and similar are return type where applicable

### DIFF
--- a/com.lisp
+++ b/com.lisp
@@ -66,6 +66,7 @@
          ,@(loop for (method return . args) in methods
                  ;; Default to hresult return
                  do (etypecase return
+                      ((cons keyword))
                       (cons
                        (push return args)
                        (setf return 'com:hresult))


### PR DESCRIPTION
keyword isn't a valid argument name, so assume it is intended as a cffi type